### PR TITLE
ignore secondary indexes

### DIFF
--- a/aegisthus-distcp/src/main/java/Distcp.java
+++ b/aegisthus-distcp/src/main/java/Distcp.java
@@ -227,6 +227,7 @@ public class Distcp extends Configured implements Tool {
 	protected int setupInput(Job job, Path inputPath, String[] inputFiles, String manifestPath) throws IOException {
 		int size = 0;
 		if (manifestPath == null) {
+			LOG.info("Setting up input");
 			FileSystem fs = inputPath.getFileSystem(job.getConfiguration());
 			DataOutputStream dos = fs.create(inputPath);
 
@@ -244,11 +245,20 @@ public class Distcp extends Configured implements Tool {
 					.statuses());
 
 			for (FileStatus file : files) {
+				Path filePath = file.getPath();
+
+				// Secondary indexes have the form <keyspace>-<table>.<index_name>-jb-4-Data.db
+				// while normal files have the form <keyspace>-<table>-jb-4-Data.db .
+				if (filePath.getName().split("\\.").length > 2) {
+					LOG.info("Skipping path " + filePath + " as it appears to be a secondary index");
+					continue;
+				}
+
 				dos.writeBytes(file.getPath().toUri().toString());
 				dos.write('\n');
+				size = size + 1;
 			}
 			dos.close();
-			size = files.size();
 		} else {
 			Utils.copy(new Path(manifestPath), inputPath, false, job.getConfiguration());
 			FileSystem fs = inputPath.getFileSystem(job.getConfiguration());


### PR DESCRIPTION
EPIC is using secondary indexes for one of their tables, so we need to ignore them while copying and decompressing (else it'll be an error later downstream).
