### PR TITLE
add option to whitelist certain keys in the mapper; also don't pass c…

### DIFF
--- a/aegisthus-hadoop/src/main/java/com/netflix/Aegisthus.java
+++ b/aegisthus-hadoop/src/main/java/com/netflix/Aegisthus.java
@@ -315,5 +315,6 @@ public class Aegisthus extends Configured implements Tool {
          * The CQL "Create Table" statement that defines the schema of the input sstables.
          */
         public static final String CONF_CQL_SCHEMA = "aegisthus.cql_schema";
+        public static final String CONF_KEY_WHITELIST = "aegisthus.key_whitelist";
     }
 }

--- a/aegisthus-hadoop/src/main/java/com/netflix/aegisthus/io/writable/AegisthusKeyMapper.java
+++ b/aegisthus-hadoop/src/main/java/com/netflix/aegisthus/io/writable/AegisthusKeyMapper.java
@@ -1,13 +1,49 @@
 package com.netflix.aegisthus.io.writable;
 
+import com.netflix.Aegisthus;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.TypeParser;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.SyntaxException;
+import org.apache.cassandra.serializers.MarshalException;
 import org.apache.hadoop.mapreduce.Mapper;
 
 import java.io.IOException;
 
 public class AegisthusKeyMapper extends Mapper<AegisthusKey, AtomWritable, AegisthusKey, AtomWritable> {
+    private AbstractType<?> rowKeyComparator;
+    
+    @Override protected void setup(
+            Context context)
+            throws IOException, InterruptedException {
+        super.setup(context);
+
+        String rowKeyType = context.getConfiguration().get(Aegisthus.Feature.CONF_KEYTYPE, "BytesType");
+
+        try {
+            rowKeyComparator = TypeParser.parse(rowKeyType);
+        } catch (SyntaxException | ConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     protected void map(AegisthusKey key, AtomWritable value, Context context)
             throws IOException, InterruptedException {
-        context.write(key, value);
+        try {
+            String[] keyWhitelist = context.getConfiguration().getStrings(Aegisthus.Feature.CONF_KEY_WHITELIST);
+            if (keyWhitelist != null && keyWhitelist.length > 0) {
+                String readableKey = rowKeyComparator.getString(key.getKey());
+                boolean matches = false;
+                for (String prefix : keyWhitelist) {
+                    if (readableKey.startsWith(prefix + "\\:")) matches = true;
+                }
+                if (!matches) return;
+            }
+            context.write(key, value);
+        } catch (MarshalException | IllegalArgumentException ignored) {
+            // don't emit key
+        }
     }
 }


### PR DESCRIPTION
…orrupt keys to the reducer

...This should have happened like a month ago, as this is the code inside the JAR we're running in production, but apparently I forgot to commit this